### PR TITLE
Fixed a bug

### DIFF
--- a/main_CN.cpp
+++ b/main_CN.cpp
@@ -658,6 +658,7 @@ void Reserve ( int a, float x, float y, int b )
 			}
 		}
 	}
+	if ( Blo < 0 ) Blo = 0;
 }
 void Map ( int a, int b )
 {


### PR DESCRIPTION
修复了玩家血量出现负数的小问题，没有经过完备的测试，合并前请检查；

Boss的血量也有这个问题，但我“修复”之后发现boss死不了了（但我不确定是否是这行代码的问题），所以就没加，具体是在3915行后面加上`if ( Bblo < 0 ) Bblo = 0;`。